### PR TITLE
sync-diff-inspector: Not to include fix sqls for disk write when exportFixSQL is false

### DIFF
--- a/sync_diff_inspector/diff.go
+++ b/sync_diff_inspector/diff.go
@@ -749,7 +749,9 @@ func (df *Diff) compareRows(ctx context.Context, rangeInfo *splitter.RangeInfo, 
 			lastDownstreamData = nil
 		}
 
-		dml.sqls = append(dml.sqls, sql)
+		if df.exportFixSQL {
+			dml.sqls = append(dml.sqls, sql)
+	    }
 	}
 	dml.rowAdd = rowsAdd
 	dml.rowDelete = rowsDelete


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
-->

Issue Number: close #870

### What is changed and how it works?
Guard this [line](https://github.com/pingcap/tidb-tools/blob/24aedc3785634cca9ed8c842b042ee37c17d7d70/sync_diff_inspector/diff.go#L712) where fix sqls are added for disk write with `export-fix-sql`.

So there won't be fix sql files created on the disk with chunk metadata.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test 
